### PR TITLE
Token counting tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,146 @@
+# Test fixtures shared across test files
+
+import pytest
+import json
+
+import tiktoken
+
+from texttunnel import chat, models
+
+
+@pytest.fixture
+def texts_fixture():
+    return [
+        "The first text.",
+        "",  # empty string
+        "The third text has non-ASCII characters: 你好世界",  # hello world in Chinese
+        "The fourth text has a newline.\n",
+    ]
+
+
+@pytest.fixture
+def texts_long_fixture():
+    n_texts = 100
+    min_length = 10
+    max_length = 1000
+
+    text_lengths = range(
+        min_length, max_length + 10, 10  # range is not inclusive
+    )  # 100 variations of text length
+
+    j = 0
+
+    # Cycle through texts lengths to create a list of texts
+    texts = []
+    for _ in range(n_texts):
+        text_length = text_lengths[j]
+        text = " ".join(["hello"] * text_length)  # Nirvana lyrics generator
+        texts.append(text)
+        if j < len(text_lengths) - 1:
+            j += 1
+        else:
+            j = 0
+
+    return texts
+
+
+@pytest.fixture
+def texts_nonascii_fixture():
+    return [
+        "Äpfel",  # apples in German
+        "👋 🌍",
+        "你好世界",  # hello world in Chinese
+    ]
+
+
+@pytest.fixture
+def encoding_fixture():
+    return tiktoken.get_encoding("cl100k_base")
+
+
+@pytest.fixture
+def response_fixture():
+    return [
+        {
+            "model": "gpt-3.5-turbo",
+            "messages": [
+                {
+                    "role": "system",
+                    "text": "You are a helpful assistant",
+                },
+                {
+                    "role": "user",
+                    "text": "How are you?",
+                },
+            ],
+            "functions": [
+                {
+                    "name": "tell_feeling",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "feeling": {
+                                "type": "string",
+                                "enum": ["happy", "sad", "angry"],
+                            }
+                        },
+                    },
+                }
+            ],
+        },
+        {
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "function_call": {
+                            "name": "tell_feeling",
+                            "arguments": json.dumps({"feeling": "happy"}),
+                        },
+                        "finish_reason": "stop",
+                    },
+                }
+            ]
+        },
+    ]
+
+
+@pytest.fixture
+def chat_fixture():
+    return chat.Chat(
+        messages=[
+            chat.ChatMessage(
+                role="system",
+                content="You are a helpful assistant.",
+            ),
+            chat.ChatMessage(
+                role="user",
+                content="Hello, world!",
+            ),
+        ]
+    )
+
+
+@pytest.fixture
+def function_fixture():
+    return {
+        "name": "function_name",
+        "parameters": {
+            "type": "object",
+            "properties": {"argument1": {"type": "string"}},
+        },
+    }
+
+
+@pytest.fixture
+def model_fixture():
+    return models.Model(
+        name="gpt-3.5-turbo",
+        context_size=4096,
+        input_token_price_per_1k=0.002,
+        output_token_price_per_1k=0.004,
+        tokens_per_minute=90000,
+        requests_per_minute=3500,
+    )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -51,7 +51,7 @@ def test_chat_completion_request_context_size_exceeded(
         )
 
 
-def test_build_pinbacked_requests_default_settings(
+def test_build_binpacked_requests_default_settings(
     model_fixture,
     function_fixture,
     texts_long_fixture,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,61 +1,6 @@
 import pytest
-import tiktoken
 
-from texttunnel import chat, models
-
-
-@pytest.fixture
-def chat_fixture():
-    return chat.Chat(
-        messages=[
-            chat.ChatMessage(
-                role="system",
-                content="You are a helpful assistant.",
-            ),
-            chat.ChatMessage(
-                role="user",
-                content="Hello, world!",
-            ),
-        ]
-    )
-
-
-@pytest.fixture
-def function_fixture():
-    return {
-        "name": "function_name",
-        "parameters": {
-            "type": "object",
-            "properties": {"argument1": {"type": "string"}},
-        },
-    }
-
-
-@pytest.fixture
-def model_fixture():
-    return models.Model(
-        name="gpt-3.5-turbo",
-        context_size=4096,
-        input_token_price_per_1k=0.002,
-        output_token_price_per_1k=0.004,
-        tokens_per_minute=90000,
-        requests_per_minute=3500,
-    )
-
-
-@pytest.fixture
-def texts_fixture():
-    return [
-        "The first text.",
-        "",  # empty string
-        "The third text has non-ASCII characters: 你好世界",  # hello world in Chinese
-        "The fourth text has a newline.\n",
-    ]
-
-
-@pytest.fixture
-def encoding_fixture():
-    return tiktoken.get_encoding("cl100k_base")
+from texttunnel import chat
 
 
 def test_chat_add_message(chat_fixture):
@@ -102,11 +47,11 @@ def test_chat_completion_request_context_size_exceeded(
             model=model_fixture,
             chat=chat_fixture,
             function=function_fixture,
-            max_output_tokens=4080, # doesn't fit
+            max_output_tokens=4080,  # doesn't fit
         )
 
 
-def test_build_binpacked_requests(
+def test_build_binpacked_requests_max_texts_per_request(
     model_fixture,
     function_fixture,
     texts_fixture,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -94,6 +94,18 @@ def test_chat_completion_request(model_fixture, chat_fixture, function_fixture):
     assert request.to_dict()["temperature"] == 0.5
 
 
+def test_chat_completion_request_context_size_exceeded(
+    model_fixture, chat_fixture, function_fixture
+):
+    with pytest.raises(ValueError):
+        chat.ChatCompletionRequest(
+            model=model_fixture,
+            chat=chat_fixture,
+            function=function_fixture,
+            max_output_tokens=4080, # doesn't fit
+        )
+
+
 def test_build_binpacked_requests(
     model_fixture,
     function_fixture,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -51,6 +51,21 @@ def test_chat_completion_request_context_size_exceeded(
         )
 
 
+def test_build_pinbacked_requests_default_settings(
+    model_fixture,
+    function_fixture,
+    texts_long_fixture,
+):
+    requests = chat.build_binpacked_requests(
+        system_message="You are a helpful assistant.",
+        model=model_fixture,
+        function=function_fixture,
+        texts=texts_long_fixture,
+    )
+
+    assert all([r.count_total_tokens() <= model_fixture.context_size for r in requests])
+
+
 def test_build_binpacked_requests_max_texts_per_request(
     model_fixture,
     function_fixture,

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,58 +1,5 @@
-import json
 from pathlib import Path
-
-import pytest
-
 from texttunnel import processor
-
-
-@pytest.fixture
-def response_fixture():
-    return [
-        {
-            "model": "gpt-3.5-turbo",
-            "messages": [
-                {
-                    "role": "system",
-                    "text": "You are a helpful assistant",
-                },
-                {
-                    "role": "user",
-                    "text": "How are you?",
-                },
-            ],
-            "functions": [
-                {
-                    "name": "tell_feeling",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "feeling": {
-                                "type": "string",
-                                "enum": ["happy", "sad", "angry"],
-                            }
-                        },
-                    },
-                }
-            ],
-        },
-        {
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": None,
-                        "function_call": {
-                            "name": "tell_feeling",
-                            "arguments": json.dumps({"feeling": "happy"}),
-                        },
-                        "finish_reason": "stop",
-                    },
-                }
-            ]
-        },
-    ]
 
 
 def test_prepare_output_filepath_tempfile():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import itertools
 
 from texttunnel import utils
 
+
 def test_num_tokens_from_text(texts_fixture):
     num_tokens = [utils.num_tokens_from_text(text) for text in texts_fixture]
     assert num_tokens == [4, 0, 15, 7]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,59 +1,7 @@
 import pytest
-import tiktoken
 import itertools
 
 from texttunnel import utils
-
-
-@pytest.fixture
-def texts_fixture():
-    return [
-        "The first text.",
-        "",  # empty string
-        "The third text has non-ASCII characters: 你好世界",  # hello world in Chinese
-        "The fourth text has a newline.\n",
-    ]
-
-
-@pytest.fixture
-def texts_long_fixture():
-    n_texts = 100
-    min_length = 10
-    max_length = 1000
-
-    text_lengths = range(
-        min_length, max_length + 10, 10  # range is not inclusive
-    )  # 100 variations of text length
-
-    j = 0
-
-    # Cycle through texts lengths to create a list of texts
-    texts = []
-    for _ in range(n_texts):
-        text_length = text_lengths[j]
-        text = " ".join(["hello"] * text_length)  # Nirvana lyrics generator
-        texts.append(text)
-        if j < len(text_lengths) - 1:
-            j += 1
-        else:
-            j = 0
-
-    return texts
-
-
-@pytest.fixture
-def texts_nonascii_fixture():
-    return [
-        "Äpfel",  # apples in German
-        "👋 🌍",
-        "你好世界",  # hello world in Chinese
-    ]
-
-
-@pytest.fixture
-def encoding_fixture():
-    return tiktoken.get_encoding("cl100k_base")
-
 
 def test_num_tokens_from_text(texts_fixture):
     num_tokens = [utils.num_tokens_from_text(text) for text in texts_fixture]

--- a/texttunnel/chat.py
+++ b/texttunnel/chat.py
@@ -249,7 +249,7 @@ class ChatCompletionRequest:
         num_input_tokens = self.count_input_tokens()
         num_output_tokens = self.count_output_tokens()
         num_total_tokens = num_input_tokens + num_output_tokens
-        
+
         if num_total_tokens > self.model.context_size:
             raise ValueError(
                 f"""
@@ -351,7 +351,8 @@ def build_binpacked_requests(
         system_message: The message to include at the beginning of each chat.
         texts: A list of texts to binpack into chats.
         max_tokens_per_request: The maximum number of tokens allowed in one request.
-            Defaults to 90% of the model's context size.
+            Defaults to 90% of the model's context size. The 10% buffer makes
+            sure that mistakes in token counting don't cause the request to fail.
         max_texts_per_request: The maximum number of texts allowed in one request.
             Defaults to None, which means there is no limit.
         max_output_tokens: The maximum number of tokens allowed in the completion.


### PR DESCRIPTION
- lets ChatCompletionRequest validate total token consumption relative to context size
- adds more tests for token counting and binpacking
- moves test fixtures to new file `conftest.py` which is automatically loaded in tests. This enables reuse of test fixtures across tests files