### PR TITLE
Pass max_output_tokens to ChatCompletionRequest

### DIFF
--- a/texttunnel/chat.py
+++ b/texttunnel/chat.py
@@ -408,6 +408,7 @@ def build_binpacked_requests(
             model=model,
             function=function,
             model_params=model_params,
+            max_output_tokens=max_output_tokens,
         )
 
         requests.append(request)


### PR DESCRIPTION
Fixes a bug where `build_binpacked_requests()` didn't pass the `max_output_tokens` argument to `ChatCompletionRequest` instances.