### PR TITLE
Handle parameters with a class

### DIFF
--- a/examples/sentiment_analysis.py
+++ b/examples/sentiment_analysis.py
@@ -52,9 +52,7 @@ requests = chat.build_binpacked_requests(
     function=function,
     model=models.GPT_3_5_TURBO,
     system_message=system_message,
-    model_params={
-        "temperature": 0.0,
-    },  # no randomness in the model's output
+    params=models.Parameters(max_tokens=50),
 )
 
 # %%

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,3 +154,8 @@ def model_fixture():
         tokens_per_minute=90000,
         requests_per_minute=3500,
     )
+
+
+@pytest.fixture
+def params_fixture():
+    return models.Parameters(max_tokens=128)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -29,7 +29,7 @@ def test_chat_completion_request(model_fixture, chat_fixture, function_fixture):
         model=model_fixture,
         chat=chat_fixture,
         function=function_fixture,
-        params=models.Parameters(temperature=0.5),
+        params=models.Parameters(max_tokens=128, temperature=0.5),
     )
 
     assert request.function_call == {"name": "function_name"}

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -52,15 +52,14 @@ def test_chat_completion_request_context_size_exceeded(
 
 
 def test_build_binpacked_requests_default_settings(
-    model_fixture,
-    function_fixture,
-    texts_long_fixture,
+    model_fixture, function_fixture, texts_long_fixture, params_fixture
 ):
     requests = chat.build_binpacked_requests(
         system_message="You are a helpful assistant.",
         model=model_fixture,
         function=function_fixture,
         texts=texts_long_fixture,
+        params=params_fixture,
     )
 
     assert all([r.count_total_tokens() <= model_fixture.context_size for r in requests])
@@ -70,6 +69,7 @@ def test_build_binpacked_requests_max_texts_per_request(
     model_fixture,
     function_fixture,
     texts_fixture,
+    params_fixture,
 ):
     requests = chat.build_binpacked_requests(
         system_message="You are a helpful assistant.",
@@ -77,6 +77,7 @@ def test_build_binpacked_requests_max_texts_per_request(
         function=function_fixture,
         texts=texts_fixture,
         max_texts_per_request=2,
+        params=models.Parameters(max_tokens=128),
     )
 
     assert len(requests) == 2
@@ -86,18 +87,22 @@ def test_build_requests(
     model_fixture,
     function_fixture,
     texts_fixture,
+    params_fixture,
 ):
     requests = chat.build_requests(
         system_message="You are a helpful assistant.",
         model=model_fixture,
         function=function_fixture,
         texts=texts_fixture,
+        params=params_fixture,
     )
 
     assert len(requests) == len(texts_fixture)
 
 
-def test_chat_completion_request_context_size_check(chat_fixture, function_fixture):
+def test_chat_completion_request_context_size_check(
+    chat_fixture, function_fixture, params_fixture
+):
     tiny_model = chat.Model(
         name="gpt-3.5-turbo",
         context_size=1,  # only for testing, real context size is 4096
@@ -112,4 +117,5 @@ def test_chat_completion_request_context_size_check(chat_fixture, function_fixtu
             model=tiny_model,
             chat=chat_fixture,
             function=function_fixture,
+            params=params_fixture,
         )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,6 +1,6 @@
 import pytest
 
-from texttunnel import chat
+from texttunnel import chat, models
 
 
 def test_chat_add_message(chat_fixture):
@@ -29,7 +29,7 @@ def test_chat_completion_request(model_fixture, chat_fixture, function_fixture):
         model=model_fixture,
         chat=chat_fixture,
         function=function_fixture,
-        model_params={"temperature": 0.5},
+        params=models.Parameters(temperature=0.5),
     )
 
     assert request.function_call == {"name": "function_name"}
@@ -47,7 +47,7 @@ def test_chat_completion_request_context_size_exceeded(
             model=model_fixture,
             chat=chat_fixture,
             function=function_fixture,
-            max_output_tokens=4080,  # doesn't fit
+            params=models.Parameters(max_tokens=4080),  # doesn't fit
         )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,3 +13,8 @@ def test_model_errors_on_negative():
             tokens_per_minute=90000,
             requests_per_minute=3500,
         )
+
+
+def test_parameters_invalid_value():
+    with pytest.raises(ValueError):
+        models.Parameters(max_tokens=128, frequency_penalty=3)

--- a/texttunnel/chat.py
+++ b/texttunnel/chat.py
@@ -219,7 +219,7 @@ class ChatCompletionRequest:
         chat: Chat,
         model: Model,
         function: FunctionDef,
-        params: Parameters = Parameters(),
+        params: Parameters,
     ):
         self.chat = chat
         self.model = model
@@ -327,13 +327,13 @@ def build_binpacked_requests(
     function: FunctionDef,
     system_message: str,
     texts: List[str],
+    params: Parameters,
     max_tokens_per_request: Optional[int] = None,
     max_texts_per_request: Optional[int] = None,
     binpacking_function: Callable = utils.binpack_texts_in_order,
     formatter_function: Callable = utils.format_texts_as_json,
     encoding_name: str = "cl100k_base",
     long_text_handling: str = "error",
-    params: Parameters = Parameters(),
 ) -> List[ChatCompletionRequest]:
     """
     Builds a list of ChatCompletionRequests from a list of texts.
@@ -350,6 +350,7 @@ def build_binpacked_requests(
             See https://platform.openai.com/docs/guides/gpt/function-calling
         system_message: The message to include at the beginning of each chat.
         texts: A list of texts to binpack into chats.
+        params: Object of class Parameters. See models.Parameters for details.
         max_tokens_per_request: The maximum number of tokens allowed in one request.
             Defaults to 90% of the model's context size. The 10% buffer makes
             sure that mistakes in token counting don't cause the request to fail.
@@ -366,7 +367,6 @@ def build_binpacked_requests(
         long_text_handling: Passed to the binpacking function. Defaults to
             "error", which means that an error will be raised if a text is too
             long to fit in a single chat.
-        params: Object of class Parameters. See models.Parameters for details.
 
     Returns:
         A list of ChatCompletionRequests.
@@ -418,9 +418,9 @@ def build_requests(
     function: FunctionDef,
     system_message: str,
     texts: List[str],
+    params: Parameters,
     encoding_name: str = "cl100k_base",
     long_text_handling: str = "error",
-    params: Parameters = Parameters(),
 ) -> List[ChatCompletionRequest]:
     """
     Builds a list of ChatCompletionRequests from a list of texts.
@@ -432,13 +432,13 @@ def build_requests(
             Must be a dictionary that describes a valid JSON schema.
             See https://platform.openai.com/docs/guides/gpt/function-calling
         system_message: The message to include at the beginning of each chat.
+        params: Object of class Parameters. See models.Parameters for details.
         texts: A list of texts to binpack into chats.
         encoding_name: The name of the encoding to use for tokenization.
             Defaults to "cl100k_base".
         long_text_handling: Passed to the binpacking function. Defaults to
             "error", which means that an error will be raised if a text is too
             long to fit in a single chat.
-        params: Object of class Parameters. See models.Parameters for details.
 
     Returns:
         A list of ChatCompletionRequests.
@@ -449,11 +449,11 @@ def build_requests(
         function=function,
         system_message=system_message,
         texts=texts,
+        params=params,
         max_tokens_per_request=None,
         max_texts_per_request=1,
         binpacking_function=utils.binpack_texts_in_order,
         formatter_function=utils.format_texts_with_spaces,
         encoding_name=encoding_name,
         long_text_handling=long_text_handling,
-        params=params,
     )

--- a/texttunnel/chat.py
+++ b/texttunnel/chat.py
@@ -30,7 +30,7 @@ from jsonschema import Draft7Validator, exceptions
 import tiktoken
 
 from texttunnel import utils
-from texttunnel.models import Model
+from texttunnel.models import Model, Parameters
 
 FunctionDef = Dict[str, str]
 
@@ -211,10 +211,7 @@ class ChatCompletionRequest:
         function: The function definition to use for the assistant's response.
             Must be a dictionary that describes a valid JSON schema.
             See https://platform.openai.com/docs/guides/gpt/function-calling
-        max_output_tokens: The maximum number of tokens allowed in the completion.
-            Defaults to 128.
-        model_params: Additional keyword arguments to pass to the OpenAI API. See
-            https://platform.openai.com/docs/api-reference/completions/create
+        params: Object of class Parameters. See models.Parameters for details.
     """
 
     def __init__(
@@ -222,8 +219,7 @@ class ChatCompletionRequest:
         chat: Chat,
         model: Model,
         function: FunctionDef,
-        max_output_tokens: int = 128,
-        model_params: Optional[Dict[str, Any]] = None,
+        params: Parameters = Parameters(),
     ):
         self.chat = chat
         self.model = model
@@ -237,12 +233,15 @@ class ChatCompletionRequest:
         self.functions = [function]
         self.function_call = {"name": function["name"]}
 
-        if model_params is None:
-            model_params = {"max_tokens": max_output_tokens}
-        else:
-            model_params["max_tokens"] = max_output_tokens
+        if params.max_tokens > self.model.context_size:
+            raise ValueError(
+                f"""
+                max_tokens ({params.max_tokens}) exceeds the context
+                size of the model ({self.model.context_size}).
+                """
+            )
 
-        self.model_params = model_params
+        self.params = params
 
         # Check that the inputs fit into the context size and leaves
         # enough space for the output
@@ -271,7 +270,7 @@ class ChatCompletionRequest:
             "messages": self.chat.to_list(),
             "functions": self.functions,
             "function_call": self.function_call,
-            **self.model_params,
+            **self.params.to_dict(),
         }
 
     def get_hash(self) -> str:
@@ -297,8 +296,7 @@ class ChatCompletionRequest:
         by the max_tokens parameter.
         """
 
-        n = self.model_params.get("n", 1)  # number of completions
-        return self.model_params["max_tokens"] * n
+        return self.params.max_tokens
 
     def count_total_tokens(self) -> int:
         """
@@ -331,12 +329,11 @@ def build_binpacked_requests(
     texts: List[str],
     max_tokens_per_request: Optional[int] = None,
     max_texts_per_request: Optional[int] = None,
-    max_output_tokens: int = 128,
     binpacking_function: Callable = utils.binpack_texts_in_order,
     formatter_function: Callable = utils.format_texts_as_json,
     encoding_name: str = "cl100k_base",
     long_text_handling: str = "error",
-    model_params: Optional[Dict[str, Any]] = None,
+    params: Parameters = Parameters(),
 ) -> List[ChatCompletionRequest]:
     """
     Builds a list of ChatCompletionRequests from a list of texts.
@@ -358,7 +355,6 @@ def build_binpacked_requests(
             sure that mistakes in token counting don't cause the request to fail.
         max_texts_per_request: The maximum number of texts allowed in one request.
             Defaults to None, which means there is no limit.
-        max_output_tokens: The maximum number of tokens allowed in the completion.
         binpacking_function: The function to use for binpacking.
             Must take a list of texts and return a list of lists of texts.
             Defaults to binpack_texts_in_order().
@@ -370,8 +366,7 @@ def build_binpacked_requests(
         long_text_handling: Passed to the binpacking function. Defaults to
             "error", which means that an error will be raised if a text is too
             long to fit in a single chat.
-        model_params: Additional keyword arguments to pass to the OpenAI API. See
-            https://platform.openai.com/docs/api-reference/completions/create
+        params: Object of class Parameters. See models.Parameters for details.
 
     Returns:
         A list of ChatCompletionRequests.
@@ -385,7 +380,7 @@ def build_binpacked_requests(
 
     # Calculate the maximum number of tokens left for the chat,
     # after accounting for the overheads and the output tokens
-    max_tokens_per_chat = max_tokens_per_request - static_tokens - max_output_tokens
+    max_tokens_per_chat = max_tokens_per_request - static_tokens - params.max_tokens
 
     # Binpack the texts into chats
     text_bins = binpacking_function(
@@ -410,8 +405,7 @@ def build_binpacked_requests(
             chat=chat,
             model=model,
             function=function,
-            model_params=model_params,
-            max_output_tokens=max_output_tokens,
+            params=params,
         )
 
         requests.append(request)
@@ -424,10 +418,9 @@ def build_requests(
     function: FunctionDef,
     system_message: str,
     texts: List[str],
-    max_output_tokens: int = 128,
     encoding_name: str = "cl100k_base",
     long_text_handling: str = "error",
-    model_params: Optional[Dict[str, Any]] = None,
+    params: Parameters = Parameters(),
 ) -> List[ChatCompletionRequest]:
     """
     Builds a list of ChatCompletionRequests from a list of texts.
@@ -440,14 +433,12 @@ def build_requests(
             See https://platform.openai.com/docs/guides/gpt/function-calling
         system_message: The message to include at the beginning of each chat.
         texts: A list of texts to binpack into chats.
-        max_output_tokens: The maximum number of tokens allowed in the completion.
         encoding_name: The name of the encoding to use for tokenization.
             Defaults to "cl100k_base".
         long_text_handling: Passed to the binpacking function. Defaults to
             "error", which means that an error will be raised if a text is too
             long to fit in a single chat.
-        model_params: Additional keyword arguments to pass to the OpenAI API. See
-            https://platform.openai.com/docs/api-reference/completions/create
+        params: Object of class Parameters. See models.Parameters for details.
 
     Returns:
         A list of ChatCompletionRequests.
@@ -460,10 +451,9 @@ def build_requests(
         texts=texts,
         max_tokens_per_request=None,
         max_texts_per_request=1,
-        max_output_tokens=max_output_tokens,
         binpacking_function=utils.binpack_texts_in_order,
         formatter_function=utils.format_texts_with_spaces,
         encoding_name=encoding_name,
         long_text_handling=long_text_handling,
-        model_params=model_params,
+        params=params,
     )

--- a/texttunnel/models.py
+++ b/texttunnel/models.py
@@ -160,7 +160,7 @@ class Parameters:
     https://platform.openai.com/docs/api-reference/chat/create
 
     Args:
-        max_tokens: The maximum number of tokens to generate. Defaults to 128. Note:
+        max_tokens: The maximum number of tokens to generate. Note:
             This can't be greater than the model's context size and should be at least
             long enough to fit the whole expected JSON output. This parameter is used
             to estimate the cost of the request.
@@ -183,7 +183,7 @@ class Parameters:
 
     def __init__(
         self,
-        max_tokens: int = 128,
+        max_tokens: int,
         temperature: float = 0.0,
         presence_penalty: float = 0.0,
         frequency_penalty: float = 0.0,

--- a/texttunnel/models.py
+++ b/texttunnel/models.py
@@ -150,3 +150,79 @@ GPT_3_5_TURBO_0301 = Model(
     tokens_per_minute=9000,
     requests_per_minute=3500,
 )
+
+
+class Parameters:
+    """
+    Set of parameters that can be passed to an API request.
+
+    The parameters are explained in the OpenAI API documentation:
+    https://platform.openai.com/docs/api-reference/chat/create
+
+    Args:
+        max_tokens: The maximum number of tokens to generate. Defaults to 128. Note:
+            This can't be greater than the model's context size and should be at least
+            long enough to fit the whole expected JSON output. This parameter is used
+            to estimate the cost of the request.
+        temperature: What sampling temperature to use, between 0 and 2.
+            Higher values like 0.8 will make the output more random, while
+            lower values like 0.2 will make it more focused and deterministic.
+            Defaults to 0.0 because this package is designed for deterministic
+            JSON-schema compliant output.
+        presence_penalty: Number between -2.0 and 2.0. Positive values penalize
+            new tokens based on whether they appear in the text so far,
+            increasing the model's likelihood to talk about new topics. Defaults to 0.0.
+        frequency_penalty: Number between -2.0 and 2.0. Positive values penalize
+            new tokens based on their existing frequency in the text so far,
+            decreasing the model's likelihood to repeat the same line verbatim.
+            Defaults to 0.0.
+
+    Parameters that are not listed here are not supported by this package. The
+    reason is that they're not relevant for the use case of this package.
+    """
+
+    def __init__(
+        self,
+        max_tokens: int = 128,
+        temperature: float = 0.0,
+        presence_penalty: float = 0.0,
+        frequency_penalty: float = 0.0,
+    ):
+        if max_tokens < 1:
+            raise ValueError("max_tokens must be positive")
+
+        if temperature < 0:
+            raise ValueError("temperature must be positive")
+
+        if temperature > 1:
+            raise ValueError("temperature must be less than or equal to 1")
+
+        if frequency_penalty < -2:
+            raise ValueError("frequency_penalty must be greater than or equal to -2")
+
+        if frequency_penalty > 2:
+            raise ValueError("frequency_penalty must be less than or equal to 2")
+
+        if presence_penalty < -2:
+            raise ValueError("presence_penalty must be greater than or equal to -2")
+
+        if presence_penalty > 2:
+            raise ValueError("presence_penalty must be less than or equal to 2")
+
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.presence_penalty = presence_penalty
+        self.frequency_penalty = frequency_penalty
+
+    def to_dict(self):
+        """
+        Returns:
+            A dictionary representation of the parameters.
+        """
+
+        return {
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "presence_penalty": self.presence_penalty,
+            "frequency_penalty": self.frequency_penalty,
+        }

--- a/texttunnel/models.py
+++ b/texttunnel/models.py
@@ -191,23 +191,14 @@ class Parameters:
         if max_tokens < 1:
             raise ValueError("max_tokens must be positive")
 
-        if temperature < 0:
-            raise ValueError("temperature must be positive")
+        if temperature < 0 or temperature > 1:
+            raise ValueError("temperature must be between 0 and 1")
 
-        if temperature > 1:
-            raise ValueError("temperature must be less than or equal to 1")
+        if frequency_penalty < -2 or frequency_penalty > 2:
+            raise ValueError("frequency_penalty must be between -2 and 2")
 
-        if frequency_penalty < -2:
-            raise ValueError("frequency_penalty must be greater than or equal to -2")
-
-        if frequency_penalty > 2:
-            raise ValueError("frequency_penalty must be less than or equal to 2")
-
-        if presence_penalty < -2:
-            raise ValueError("presence_penalty must be greater than or equal to -2")
-
-        if presence_penalty > 2:
-            raise ValueError("presence_penalty must be less than or equal to 2")
+        if presence_penalty < -2 or presence_penalty > 2:
+            raise ValueError("presence_penalty must be between -2 and 2")
 
         self.max_tokens = max_tokens
         self.temperature = temperature

--- a/texttunnel/processor.py
+++ b/texttunnel/processor.py
@@ -441,6 +441,7 @@ class APIRequest:
         output_filepath: Path,
         status_tracker: StatusTracker,
         cache: Optional[dc.Cache] = None,
+        timeout_seconds: int = 120,
     ):
         """
         Calls the OpenAI API and appends the request and result to a JSONL file.
@@ -456,13 +457,17 @@ class APIRequest:
             status_tracker: A StatusTracker object that tracks the greater
                 request loop's progress.
             cache: A diskcache.Cache object to store API responses in. Optional.
+            timeout_seconds: The number of seconds to wait for a response before
+                timing out. Defaults to 120 seconds.
         """
 
         error = None
 
         logging.info(f"Starting request #{self.task_id}")
+        timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
                 async with session.post(
                     url=request_url, headers=request_header, json=self.request.to_dict()
                 ) as response:

--- a/texttunnel/processor.py
+++ b/texttunnel/processor.py
@@ -330,9 +330,6 @@ async def aprocess_api_requests(
                 status_tracker.num_tasks_in_progress += 1
                 logging.debug(f"Reading request {next_request.task_id}: {next_request}")
 
-            else:
-                logging.debug("All tasks have been started.")
-
         # update available capacity
         current_time = time.time()
         seconds_since_update = current_time - last_update_time


### PR DESCRIPTION
This PR turns the `model_params` argument of many functions to `params`, which expects and object of type `Parameters`. 

The benefits of the new `Parameters` class are:

- no need to worry about parameters like `n`, which mess with output token estimation
- enable setting temperature to 0 by default
- have complete parameter settings in every request, which helps with hitting the cache
- validate ranges of parameters