### PR TITLE
Add information about nest_asyncio

### DIFF
--- a/texttunnel/processor.py
+++ b/texttunnel/processor.py
@@ -115,6 +115,10 @@ def process_api_requests(
     event loop. Also sorts the output by request ID, so that the results are in
     the same order as the requests.
 
+    Note that if you're running this function in a Jupyter notebook, the function
+    will automatically import nest_asyncio and call nest_asyncio.apply() to allow
+    asyncio to run in the notebook environment. This does not happen in a script.
+
     Args:
         requests: List[ChatCompletionRequest]
             The requests to process, see ChatCompletionRequest class for details
@@ -168,9 +172,14 @@ def process_api_requests(
 
     # Handle Notebook environment
     if "ipykernel" in sys.modules:
+        # nest_asyncio is a workaround for running asyncio in Jupyter notebooks
+        # it's always available when ipykernel is available
         import nest_asyncio
 
         nest_asyncio.apply()
+        logging.info(
+            "Running in Jupyter notebook environment. Activated nest_asyncio to allow asyncio to run."
+        )
 
     # Check that the cache is configured correctly
     if cache is not None:


### PR DESCRIPTION
Inform users about the use of nest_asyncio. The current behavior may be seen as intrusive by expert users, but saves beginner users from having a bad experience running texttunnel in a Jupyter notebook. If you're an expert user reading this in the future and would like it changed, please let me know and we can discuss.