### PR TITLE
Separate async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# History
+# Changelog for texttunnel
+
+## 0.3.1
+
+- Made `aprocess_api_requests()` independently useable to allow advanced users to take full control of the asyncio event loop.
+- Added text classification example.
 
 ## 0.3.0
 

--- a/examples/sentiment_analysis.py
+++ b/examples/sentiment_analysis.py
@@ -1,3 +1,6 @@
+# Example of using the texttunnel package to perform sentiment analysis
+# Features binpacking to reduce the number of API calls
+
 # %%
 import logging
 from aiohttp_client_cache import SQLiteBackend

--- a/examples/text_classification.py
+++ b/examples/text_classification.py
@@ -1,0 +1,73 @@
+# Example of using the texttunnel package to perform text classification
+# Uses the aprocess_api_call for more control over the event loop
+
+# %%
+import logging
+from aiohttp_client_cache import SQLiteBackend
+import asyncio
+import nest_asyncio
+
+from texttunnel import chat, models, processor
+
+nest_asyncio.apply()  # to allow for asyncio.run() within Jupyter
+
+# %%
+
+# Create a SQLite cache to store the results of the requests
+# When this script is run again, the results will be loaded from the cache
+# Requires the additional package aiosqlite (pip install aiosqlite)
+cache = SQLiteBackend(cache_name="openai_cache.sqlite", allowed_methods=["POST"])
+logging.basicConfig(level=logging.INFO)
+
+# Texts that we'd like to know the sentiment of
+input_texts = [
+    "The 60% layout is great for travel, but I wish it had arrow keys",
+    "The laser doesn't work on my glass desk. I'm returning it.",
+    "I love the feel of the keys, but the RGB lighting is too bright.",
+    "The scroll wheel is too sensitive. I keep scrolling past what I want.",
+]
+
+# Describe the output format that we'd like to receive,
+# using JSON Schema
+function = {
+    "name": "sentiment_analysis",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "category": {
+                "type": "string",
+                "enum": ["keyboard", "mouse"],
+            },
+        },
+        "required": ["answers"],
+    },
+}
+
+system_message = "Classify reviews by product category."
+
+model = models.GPT_3_5_TURBO
+
+requests = chat.build_requests(
+    texts=input_texts,
+    function=function,
+    model=model,
+    system_message=system_message,
+    params=models.Parameters(max_tokens=50),
+)
+
+# %%
+# Create an event loop and run the requests
+# Alternatively, use processor.process_api_requests() and let it handle the event loop
+loop = asyncio.get_event_loop()
+responses = loop.run_until_complete(
+    processor.aprocess_api_requests(requests, cache=cache)
+)
+
+# %%
+# Display the results
+results = [
+    processor.parse_arguments(response=response)["category"] for response in responses
+]
+
+for text, result in zip(input_texts, results):
+    print(f"{text}: {result}")

--- a/examples/text_classification.py
+++ b/examples/text_classification.py
@@ -30,7 +30,7 @@ input_texts = [
 # Describe the output format that we'd like to receive,
 # using JSON Schema
 function = {
-    "name": "sentiment_analysis",
+    "name": "text_classification",
     "parameters": {
         "type": "object",
         "properties": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "texttunnel"
-version = "0.3.0"
+version = "0.3.1"
 description = "Efficient text processing with the OpenAI API"
 authors = ["Q Agentur für Forschung GmbH <info@teamq.de>"]
 readme = "README.md"

--- a/texttunnel/processor.py
+++ b/texttunnel/processor.py
@@ -94,7 +94,7 @@ def process_api_requests(
 ) -> List[Response]:
     """
     Make requests to OpenAI. This function is a wrapper around
-    aprocess_api_requests() that runs it in a synchronous loop, saving you the
+    aprocess_api_requests() that executes it within asyncio.run, saving you the
     trouble of having to use asyncio directly.
 
     Note that if you're running this function in a Jupyter notebook, the function


### PR DESCRIPTION
This PR turns `process_api_requests()` into a pure wrapper of `aprocess_api_requests()`. This lets users that need fine control over the event loop run `aprocess_api_requests()` while not forcing others to learn about asyncio.

The PR also separates code into simpler functions and adds a new example for text classification that shows how to work with `aprocess_api_requests()` directly.