### PR TITLE
Detect duplicate requests and raise error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## 0.3.2
 
+Changes:
+
 - `chat.build_requests` and `chat.build_binpacked_requests` now raise a ValueError when the text argument contains duplicates
 - `aprocess_api_requests` now raises a ValueError when the requests passed to it have duplicate hashes
 
 Both of these changes are to prevent waste of money on duplicate API requests. They also prevent a sorting error where results wouldn't be returned in the same order as the requests were passed in.
+
+Bug fixes:
+
+- Fixed a bug where aiohttp sessions were not closed when an error occurred in the request
 
 ## 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for texttunnel
 
+## 0.3.2
+
+- `chat.build_requests` and `chat.build_binpacked_requests` now raise a ValueError when the text argument contains duplicates
+- `aprocess_api_requests` now raises a ValueError when the requests passed to it have duplicate hashes
+
+Both of these changes are to prevent waste of money on duplicate API requests. They also prevent a sorting error where results wouldn't be returned in the same order as the requests were passed in.
+
 ## 0.3.1
 
 - Made `aprocess_api_requests()` independently useable to allow advanced users to take full control of the asyncio event loop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "texttunnel"
-version = "0.3.1"
+version = "0.3.2"
 description = "Efficient text processing with the OpenAI API"
 authors = ["Q Agentur für Forschung GmbH <info@teamq.de>"]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,25 @@ def encoding_fixture():
 
 
 @pytest.fixture
+def requests_fixture():
+    function_def: chat.FunctionDef = {
+        "name": "tell_feeling",
+        "parameters": {
+            "type": "object",
+            "properties": {"feeling": {"type": "string"}},
+        },
+    }
+
+    return chat.build_requests(
+        system_message="You are a helpful assistant.",
+        model=models.GPT_3_5_TURBO,
+        function=function_def,
+        texts=["I am happy.", "I am sad."],
+        params=models.Parameters(max_tokens=128),
+    )
+
+
+@pytest.fixture
 def response_fixture():
     return [
         {

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -92,7 +92,7 @@ def test_build_binpacked_requests_max_texts_per_request(
         function=function_fixture,
         texts=texts_fixture,
         max_texts_per_request=2,
-        params=models.Parameters(max_tokens=128),
+        params=params_fixture,
     )
 
     assert len(requests) == 2
@@ -113,6 +113,22 @@ def test_build_requests(
     )
 
     assert len(requests) == len(texts_fixture)
+
+
+def test_build_requests_fails_on_duplicate_texts(
+    model_fixture,
+    function_fixture,
+    texts_fixture,
+    params_fixture,
+):
+    with pytest.raises(ValueError):
+        chat.build_requests(
+            system_message="You are a helpful assistant.",
+            model=model_fixture,
+            function=function_fixture,
+            texts=[texts_fixture[0], texts_fixture[0]],
+            params=params_fixture,
+        )
 
 
 def test_chat_completion_request_context_size_check(

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pytest
 from texttunnel import processor
 
 
@@ -44,3 +45,13 @@ def test_usage_to_cost(response_fixture, model_fixture):
     cost = processor.usage_to_cost(usage, model_fixture)
 
     assert cost > 0
+
+
+def test_process_api_requests_fails_on_duplicate_requests(requests_fixture):
+    with pytest.raises(ValueError):
+        processor.process_api_requests(
+            requests=[
+                requests_fixture[0],
+                requests_fixture[0],
+            ]
+        )

--- a/texttunnel/chat.py
+++ b/texttunnel/chat.py
@@ -360,7 +360,7 @@ def build_binpacked_requests(
             Must be a dictionary that describes a valid JSON schema.
             See https://platform.openai.com/docs/guides/gpt/function-calling
         system_message: The message to include at the beginning of each chat.
-        texts: A list of texts to binpack into chats.
+        texts: A list of texts to binpack into chats. Duplicates are not allowed.
         params: Object of class Parameters. See models.Parameters for details.
         max_tokens_per_request: The maximum number of tokens allowed in one request.
             Defaults to 90% of the model's context size. The 10% buffer makes
@@ -450,7 +450,7 @@ def build_requests(
             See https://platform.openai.com/docs/guides/gpt/function-calling
         system_message: The message to include at the beginning of each chat.
         params: Object of class Parameters. See models.Parameters for details.
-        texts: A list of texts to binpack into chats.
+        texts: A list of texts to binpack into chats. Duplicates are not allowed.
         encoding_name: The name of the encoding to use for tokenization.
             Defaults to "cl100k_base".
         long_text_handling: Passed to the binpacking function. Defaults to

--- a/texttunnel/chat.py
+++ b/texttunnel/chat.py
@@ -382,6 +382,12 @@ def build_binpacked_requests(
     Returns:
         A list of ChatCompletionRequests.
     """
+    if len(set(texts)) != len(texts):
+        # Downstream code assumes that each request has a unique hash
+        # Duplicate texts would cause the requests to have the same hash
+        # Plus it's probably a mistake and would waste money
+        raise ValueError("Duplicate texts found. Please remove duplicates.")
+
     if max_tokens_per_request is None:
         max_tokens_per_request = int(model.context_size * 0.9)
 

--- a/texttunnel/processor.py
+++ b/texttunnel/processor.py
@@ -107,7 +107,8 @@ def process_api_requests(
 
     Args:
         requests: List[ChatCompletionRequest]
-            The requests to process, see ChatCompletionRequest class for details
+            The requests to process, see ChatCompletionRequest class for details.
+            Duplicate requests are not allowed.
         output_filepath: str, optional
             Path to the file where the results will be saved
             file will be a jsonl file, where each line is an array with the original
@@ -194,7 +195,8 @@ async def aprocess_api_requests(
 
     Args:
         requests: List[ChatCompletionRequest]
-            The requests to process, see ChatCompletionRequest class for details
+            The requests to process, see ChatCompletionRequest class for details.
+            Duplicate requests are not allowed.
         output_filepath: str, optional
             Path to the file where the results will be saved
             file will be a jsonl file, where each line is an array with the original

--- a/texttunnel/processor.py
+++ b/texttunnel/processor.py
@@ -232,6 +232,11 @@ async def aprocess_api_requests(
             - the API response
     """
 
+    if len(requests) != len(set([request.get_hash() for request in requests])):
+        # Duplicate requests can cause problems with ordering of results
+        # Plus it's probably a mistake and would waste money
+        raise ValueError("Duplicate requests detected. Each request must be unique.")
+
     # This function was adapted from openai-cookbook
 
     # The function is structured as follows:


### PR DESCRIPTION
This change is somewhat debatable. Carefree users may prefer duplicate texts to just be handled, perhaps with a warning instead of an error.

However, efficiency and correctness is the only reason to choose to use texttunnel over the openai package in the first place, so I think typical users of the package would hate wasting money on duplicate requests.