### PR TITLE
Allow jsonschema from version 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = ">=3.9 <4.0"
 aiohttp = ">=3.8.3 <4.0.0"
-jsonschema = ">=4.18.0 <5.0.0"
+jsonschema = ">=3.0.0 <5.0.0"
 tiktoken = ">=0.3.1 <1.0.0"
 aiohttp-client-cache = ">=0.8.0 <1.0.0"
 


### PR DESCRIPTION
Version requirement for jsonschema was unnecessarily narrow.
Ran tests and example with jsonschema 3.0.0.
See also: https://pypi.org/project/jsonschema/#history