### PR TITLE
Raise exception on error in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog for texttunnel
 
+## 0.3.4
+
+Changes:
+
+- additional DEBUG level logs for cached requests
+
+Bug fixes:
+
+- `aprocess_api_requests` no longer gets stuck after a request fails
+- aiohttp sessions are now properly closed after an error occurs in the request
+
 ## 0.3.3
 
 Changes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "texttunnel"
-version = "0.3.3"
+version = "0.3.4"
 description = "Efficient text processing with the OpenAI API"
 authors = ["Q Agentur für Forschung GmbH <info@teamq.de>"]
 readme = "README.md"


### PR DESCRIPTION
An error in an API response does not raise an exception, causing the following except block to be skipped. This could lead to an infinite loop because capacity claimed by a retried run isn't freed up again.

This PR explicitly raises an exception in those cases, correctly triggering the following except block.